### PR TITLE
Add dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pillow
 decord
 git+https://github.com/huggingface/transformers
 av
+einops
+accelerate


### PR DESCRIPTION
At least `einops` was required (and not installed per default in a new virtualenv) in my case.

As for accelerate:

> For stability purposes, it is recommended to have accelerate installed when using this model in torch.float16, please install it with `pip install accelerate`