### PR TITLE
Optimize the calculation method of frame_step

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -169,8 +169,11 @@ class PreProcessVideos:
                     try:
                         video_reader = VideoReader(video_path, ctx=cpu(0))
                         video_len = len(video_reader)
-                        frame_step = abs(video_len // self.prompt_amount)
-                        derterministic_range = range(1, abs(video_len - 1), frame_step)          
+                        if video_len < self.prompt_amount:
+                            frame_step = 1
+                        else:
+                            frame_step = abs(video_len // self.prompt_amount)
+                        derterministic_range = range(1, abs(video_len - 1), frame_step)
                     except:
                         print(f"Error loading {video_path}. Video may be unsupported or corrupt.")
                         continue


### PR DESCRIPTION
When I run preprocess.py I get an error:
```
Error loading /root/Video-BLIP2-Preprocessor/videos/resize_512_512/0_1705709301127_fe3cec89-5b0a-449e-b60c-6958c7617a8e_h264_512_512.mp4. Video may be unsupported or corrupt.
Traceback (most recent call last):
  File "/root/Video-BLIP2-Preprocessor/preprocess.py", line 174, in process_videos
    derterministic_range = range(1, abs(video_len - 1), frame_step)
ValueError: range() arg 3 must not be zero
```
I discovered that the issue arises because the total frame count of my video is less than the default prompt_amount, resulting in a frame_step value of zero. I believe that throwing an error in this scenario is not user-friendly. It would be more appropriate to set the step size to 1 when the video's frame count is below prompt_amount.